### PR TITLE
set up json5 mode, json5 demo, simpler exports

### DIFF
--- a/.changeset/ninety-ducks-flow.md
+++ b/.changeset/ninety-ducks-flow.md
@@ -1,0 +1,5 @@
+---
+"cm6-json-schema": minor
+---
+
+add json5 support, simpler exports

--- a/README.md
+++ b/README.md
@@ -1,28 +1,85 @@
-# `cm6-json-schema`
+# `codemirror-json-schema`
 
-Provides a json-schema enabled mode that extends `@codemirror/lang-json`'s grammar for codemirror 6 that:
+Builds on `@codemirror/lang-json`'s and `codemirror-json5`'s grammars with JSONSchema support!
 
-- [x] `lint`s: validates json strings with positional information for json schema errors
-- [x] `hint`s: provides code completion
-- [x] `info`s: provides hover info
-- [ ] leverages `$schema` path url if provided in the JSON string, or a json schema that is provided to the mode API, preferring the former.
+## json4
 
-Coming soon: `json5` support using `codemirror-json5`'s grammar! Utilities already exist :)
+- [x] `lint`s: validates json against schema
+- [x] `hint`s: provides code completion (no complex types yet)
+- [x] `info`s: provides hover tooltip
+
+## json5
+
+- [x] `lint`s: validates json against schema
+- [x] `info`s: provides hover tooltip
+- [ ] `hint`s: provides code completion
 
 ### Usage
 
-You can start with the [deployed example](https://github.com/acao/cm6-json-schema/blob/main/dev/index.ts) to learn how to use it. Many more docs to come!
+You will need to install the relevant language mode for our library to use.
+
+## json4
+
+```
+npm install --save @codemirror/lang-json codemirror-json-schema
+```
+
+```ts
+import { json } from "@codemirror/lang-json";
+import { jsonSchemaLinting, jsonSchemaHover } from "codemirror-json-schema";
+
+const state = EditorState.create({
+  doc: jsonText,
+  extensions: [
+    json(),
+    linter(jsonParseLinter()),
+    linter(jsonSchemaLinter(schema)),
+    jsonLanguage.data.of({
+      autocomplete: jsonCompletion(schema),
+    }),
+    hoverTooltip(jsonSchemaHover(schema)),
+  ];
+})
+```
+
+## json5
+
+```
+npm install --save codemirror-json codemirror-json-schema json5
+```
+
+```ts
+import { json5 } from "codemirror-json5";
+import {
+  jsonSchemaLinting,
+  jsonSchemaHover,
+} from "codemirror-json-schema/json5";
+
+const json5State = EditorState.create({
+  doc: json5Text,
+  extensions: [
+    ...commonExtensions,
+    json5(),
+    linter(json5ParseLinter()),
+    linter(json5SchemaLinter(schema)),
+    hoverTooltip(json5SchemaHover(schema)),
+  ],
+});
+```
+
+You can start with the [deployed example](https://github.com/acao/cm6-json-schema/blob/main/dev/index.ts) to learn advanced usage. Many more docs to come!
 
 ## Current constraints:
 
 - only linting & hover is available for `oneOf`, `anyOf`, `allOf` and other [schema combination methods](https://json-schema.org/understanding-json-schema/reference/combining.html)
-- it only works with one json schema instance at a time, and doesn't yet fetch remote schemas
+- it only works with one json schema instance at a time, and doesn't yet fetch remote schemas. schema service coming soon!
 
 ## Inspiration
 
 `monaco-json` and `monaco-yaml` both provide these features, and I want the nascent codemirror 6 to have them as well!
 
-## Goals
+## Our Goals
+
 - working GeoJSON spec linter & completion
 - working variables json mode for `cm6-graphql`, ala `monaco-graphql`
-- json5 + json schema for all!
+- json5 + json4 json schema features for all!

--- a/dev/index.html
+++ b/dev/index.html
@@ -5,16 +5,36 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite App</title>
     <style>
+      body {
+        background-color: #282c34;
+        color: var(--fbc-light-gray);
+        font-family: "Lucida Sans", "Lucida Sans Regular", "Lucida Grande",
+          "Lucida Sans Unicode", Geneva, Verdana, sans-serif;
+      }
+      code {
+        background-color: #1f2329;
+        color: var(--fbc-light-gray);
+        padding: 0.2rem;
+        font-family: "Lucida Console", Monaco, monospace;
+      }
+      /* cm6 styles */
       .cm-lintRange-error {
         text-decoration: underline wavy red;
       }
-      body {
-        background-color: #282c34;
+      .cm6-json-schema-hover,
+      .cm-editor .cm-diagnostic-error {
+        padding: 0.5rem;
       }
     </style>
   </head>
   <body class="replit-ui-theme-root dark">
+    <h1><code>codemirror-json-schema</code> demo</h1>
+    <h2><code>package.json</code> demo</h2>
+    <p>Supports simple completion, linting, hover</p>
     <div id="editor"></div>
+    <h2><code>package.json5</code> demo</h2>
+    <p>Supports linting, hover</p>
+    <div id="editor-json5"></div>
     <script type="module" src="./index.ts"></script>
   </body>
 </html>

--- a/dev/index.ts
+++ b/dev/index.ts
@@ -1,9 +1,9 @@
 import {
   JSONCompletion,
-  lintJSONSchema,
-  hoverJsonSchema,
-  lintJSON5Schema,
-  hoverJson5Schema,
+  jsonSchemaLiner,
+  jsonSchemaHover,
+  json5SchemaLinter,
+  json5SchemaHover,
 } from "../src";
 import { EditorState } from "@codemirror/state";
 import {
@@ -53,11 +53,11 @@ const state = EditorState.create({
     ...commonExtensions,
     json(),
     linter(jsonParseLinter()),
-    linter(lintJSONSchema(schema)),
+    linter(jsonSchemaLiner(schema)),
     jsonLanguage.data.of({
       autocomplete: (ctx: CompletionContext) => jsonCompletion.doComplete(ctx),
     }),
-    hoverTooltip(hoverJsonSchema(schema)),
+    hoverTooltip(jsonSchemaHover(schema)),
   ],
 });
 
@@ -72,8 +72,8 @@ const json5State = EditorState.create({
     ...commonExtensions,
     json5(),
     linter(json5ParseLinter()),
-    linter(lintJSON5Schema(schema)),
-    hoverTooltip(hoverJson5Schema(schema)),
+    linter(json5SchemaLinter(schema)),
+    hoverTooltip(json5SchemaHover(schema)),
   ],
 });
 

--- a/dev/index.ts
+++ b/dev/index.ts
@@ -1,49 +1,85 @@
-import { JSONCompletion, JSONHover, JSONValidation } from "../src";
-import { EditorState } from '@codemirror/state';
-import { gutter, EditorView, lineNumbers, hoverTooltip } from '@codemirror/view';
-import { basicSetup } from 'codemirror'
-import { history } from '@codemirror/commands';
-import { autocompletion, closeBrackets, CompletionContext } from '@codemirror/autocomplete';
-import { linter, lintGutter } from '@codemirror/lint';
-import { bracketMatching, syntaxHighlighting } from '@codemirror/language';
-import { oneDarkHighlightStyle, oneDark } from '@codemirror/theme-one-dark';
-import {jsonText} from './sample-text';
-import packageJsonSchema from './package.schema.json';
-import { json, jsonLanguage, jsonParseLinter } from '@codemirror/lang-json';
-import { JSONSchema7 } from 'json-schema';
+import {
+  JSONCompletion,
+  lintJSONSchema,
+  hoverJsonSchema,
+  lintJSON5Schema,
+  hoverJson5Schema,
+} from "../src";
+import { EditorState } from "@codemirror/state";
+import {
+  gutter,
+  EditorView,
+  lineNumbers,
+  hoverTooltip,
+} from "@codemirror/view";
+import { basicSetup } from "codemirror";
+import { history } from "@codemirror/commands";
+import {
+  autocompletion,
+  closeBrackets,
+  CompletionContext,
+} from "@codemirror/autocomplete";
+import { linter, lintGutter } from "@codemirror/lint";
+import { bracketMatching, syntaxHighlighting } from "@codemirror/language";
+import { oneDarkHighlightStyle, oneDark } from "@codemirror/theme-one-dark";
+import { json5, json5ParseLinter } from "codemirror-json5";
+import { jsonText, json5Text } from "./sample-text";
+import packageJsonSchema from "./package.schema.json";
+import { json, jsonLanguage, jsonParseLinter } from "@codemirror/lang-json";
+import { JSONSchema7 } from "json-schema";
+
+const schema = packageJsonSchema as JSONSchema7;
 
 const jsonCompletion = new JSONCompletion(packageJsonSchema as JSONSchema7);
-const jsonLinting =  new JSONValidation(packageJsonSchema as JSONSchema7);
-const jsonHover = new JSONHover(packageJsonSchema as JSONSchema7);
+
+const commonExtensions = [
+  gutter({ class: "CodeMirror-lint-markers" }),
+  bracketMatching(),
+  basicSetup,
+  closeBrackets(),
+  history(),
+  autocompletion(),
+  lineNumbers(),
+  lintGutter(),
+  oneDark,
+  EditorView.lineWrapping,
+  EditorState.tabSize.of(2),
+  syntaxHighlighting(oneDarkHighlightStyle),
+];
 
 const state = EditorState.create({
   doc: jsonText,
   extensions: [
-    gutter({class: 'CodeMirror-lint-markers'}),
-    bracketMatching(),
-    basicSetup,
-    closeBrackets(),
-    history(),
-    autocompletion(),
-    lineNumbers(),
-    lintGutter(),
-    oneDark,
-    EditorView.lineWrapping,
-    EditorState.tabSize.of(2),
-    syntaxHighlighting(oneDarkHighlightStyle),
+    ...commonExtensions,
     json(),
     linter(jsonParseLinter()),
-    linter((view) => jsonLinting.doValidation(view)),
+    linter(lintJSONSchema(schema)),
     jsonLanguage.data.of({
       autocomplete: (ctx: CompletionContext) => jsonCompletion.doComplete(ctx),
     }),
-    hoverTooltip((view, pos, side) => jsonHover.doHover(view, pos, side)),
+    hoverTooltip(hoverJsonSchema(schema)),
   ],
 });
 
 new EditorView({
   state,
-  parent: document.querySelector('#editor')!,
+  parent: document.querySelector("#editor")!,
+});
+
+const json5State = EditorState.create({
+  doc: json5Text,
+  extensions: [
+    ...commonExtensions,
+    json5(),
+    linter(json5ParseLinter()),
+    linter(lintJSON5Schema(schema)),
+    hoverTooltip(hoverJson5Schema(schema)),
+  ],
+});
+
+new EditorView({
+  state: json5State,
+  parent: document.querySelector("#editor-json5")!,
 });
 
 // Hot Module Replacement

--- a/dev/index.ts
+++ b/dev/index.ts
@@ -1,10 +1,3 @@
-import {
-  JSONCompletion,
-  jsonSchemaLiner,
-  jsonSchemaHover,
-  json5SchemaLinter,
-  json5SchemaHover,
-} from "../src";
 import { EditorState } from "@codemirror/state";
 import {
   gutter,
@@ -14,23 +7,25 @@ import {
 } from "@codemirror/view";
 import { basicSetup } from "codemirror";
 import { history } from "@codemirror/commands";
-import {
-  autocompletion,
-  closeBrackets,
-  CompletionContext,
-} from "@codemirror/autocomplete";
+import { autocompletion, closeBrackets } from "@codemirror/autocomplete";
 import { linter, lintGutter } from "@codemirror/lint";
 import { bracketMatching, syntaxHighlighting } from "@codemirror/language";
 import { oneDarkHighlightStyle, oneDark } from "@codemirror/theme-one-dark";
-import { json5, json5ParseLinter } from "codemirror-json5";
-import { jsonText, json5Text } from "./sample-text";
-import packageJsonSchema from "./package.schema.json";
-import { json, jsonLanguage, jsonParseLinter } from "@codemirror/lang-json";
 import { JSONSchema7 } from "json-schema";
 
-const schema = packageJsonSchema as JSONSchema7;
+// sample data
+import { jsonText, json5Text } from "./sample-text";
+import packageJsonSchema from "./package.schema.json";
 
-const jsonCompletion = new JSONCompletion(packageJsonSchema as JSONSchema7);
+// json4
+import { json, jsonLanguage, jsonParseLinter } from "@codemirror/lang-json";
+import { jsonSchemaLinter, jsonSchemaHover, jsonCompletion } from "../src";
+
+// json5
+import { json5, json5ParseLinter } from "codemirror-json5";
+import { json5SchemaLinter, json5SchemaHover } from "../src/json5";
+
+const schema = packageJsonSchema as JSONSchema7;
 
 const commonExtensions = [
   gutter({ class: "CodeMirror-lint-markers" }),
@@ -53,9 +48,9 @@ const state = EditorState.create({
     ...commonExtensions,
     json(),
     linter(jsonParseLinter()),
-    linter(jsonSchemaLiner(schema)),
+    linter(jsonSchemaLinter(schema)),
     jsonLanguage.data.of({
-      autocomplete: (ctx: CompletionContext) => jsonCompletion.doComplete(ctx),
+      autocomplete: jsonCompletion(schema),
     }),
     hoverTooltip(jsonSchemaHover(schema)),
   ],

--- a/dev/sample-text.ts
+++ b/dev/sample-text.ts
@@ -3,3 +3,9 @@ export const jsonText = `{
   "version": "0.0.0",
   "description": "A lexicon for the unicon programming language",
 }`;
+export const json5Text = `{
+  "name": "lexunicon",
+  'version': "0.0.0",
+  description: "A lexicon for the unicon programming language",
+  contributors: false,
+}`;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cm6-json-schema",
+  "name": "codemirror-json-schema",
   "license": "MIT",
   "version": "0.0.1",
   "description": "A JSONSchema enabled mode for codemirror 6, inspired by monaco-json",
@@ -17,9 +17,19 @@
   "packageManager": "pnpm@8.6.6",
   "types": "dist/index.d.ts",
   "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./json5": {
+      "import": "./dist/json5.js",
+      "types": "./dist/json5.d.ts"
+    }
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/acao/cm6-language-json-schema.git"
+    "url": "https://github.com/acao/codemirror-json-schema.git"
   },
   "dependencies": {
     "@changesets/cli": "^2.26.2",

--- a/src/__tests__/json-hover.spec.ts
+++ b/src/__tests__/json-hover.spec.ts
@@ -63,7 +63,7 @@ describe("JSONHover#doHover", () => {
     });
     const hoverEl = hoverResult?.create(new EditorView({})).dom;
     expect(hoverEl).toContainHTML(
-      "<div><div>an elegant string</div><div><code>string</code></div></div>"
+      '<div class="cm6-json-schema-hover"><div>an elegant string</div><div><code>string</code></div></div>'
     );
   });
   it("should not fail for oneOf", async () => {

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,5 +1,5 @@
 export const debug = {
   log: (...args: any[]) => {
     console.log(...args);
-  }
-}
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 export { JSONCompletion } from "./json-completion";
 export {
   JSONValidation,
-  lintJSONSchema,
+  jsonSchemaLiner,
   type JSONValidationOptions,
 } from "./json-validation";
-export { JSONHover, type HoverOptions, hoverJsonSchema } from "./json-hover";
+export { JSONHover, type HoverOptions, jsonSchemaHover } from "./json-hover";
 
 // export utilities for general use
 export * from "./utils/parseJSONDocument";
@@ -12,5 +12,5 @@ export * from "./utils/jsonPointers";
 export * from "./utils/parseJSON5Document";
 
 // json5
-export { lintJSON5Schema } from "./json5-validation";
-export { hoverJson5Schema } from "./json5-hover";
+export { json5SchemaLinter } from "./json5-validation";
+export { json5SchemaHover } from "./json5-hover";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,16 @@
 export { JSONCompletion } from "./json-completion";
-export { JSONValidation } from "./json-validation";
-export { JSONHover, type HoverOptions } from "./json-hover";
+export {
+  JSONValidation,
+  lintJSONSchema,
+  type JSONValidationOptions,
+} from "./json-validation";
+export { JSONHover, type HoverOptions, hoverJsonSchema } from "./json-hover";
 
 // export utilities for general use
 export * from "./utils/parseJSONDocument";
 export * from "./utils/jsonPointers";
 export * from "./utils/parseJSON5Document";
+
+// json5
+export { lintJSON5Schema } from "./json5-validation";
+export { hoverJson5Schema } from "./json5-hover";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,8 @@
-export { JSONCompletion } from "./json-completion";
-export {
-  JSONValidation,
-  jsonSchemaLiner,
-  type JSONValidationOptions,
-} from "./json-validation";
-export { JSONHover, type HoverOptions, jsonSchemaHover } from "./json-hover";
+export { jsonCompletion } from "./json-completion";
+export { jsonSchemaLinter, type JSONValidationOptions } from "./json-validation";
+export { type HoverOptions, jsonSchemaHover } from "./json-hover";
 
 // export utilities for general use
 export * from "./utils/parseJSONDocument";
 export * from "./utils/jsonPointers";
 export * from "./utils/parseJSON5Document";
-
-// json5
-export { json5SchemaLinter } from "./json5-validation";
-export { json5SchemaHover } from "./json5-hover";

--- a/src/json-completion.ts
+++ b/src/json-completion.ts
@@ -813,3 +813,10 @@ export class JSONCompletion {
     return str.replace(/^"(.*)"$/, '$1').replace(/^'(.*)'$/, '$1');
   }
 }
+
+export function jsonCompletion(schema: JSONSchema7) {
+  const completion = new JSONCompletion(schema)
+  return function doJSONCompletion(ctx: CompletionContext) {
+    return completion.doComplete(ctx)
+  }
+}

--- a/src/json-hover.ts
+++ b/src/json-hover.ts
@@ -17,7 +17,7 @@ export type HoverOptions = {
   // onHover?: () => void;
 };
 
-export function hoverJsonSchema(schema: JSONSchema7, options?: HoverOptions) {
+export function jsonSchemaHover(schema: JSONSchema7, options?: HoverOptions) {
   const hover = new JSONHover(schema, options);
   return async function jsonDoHover(
     view: EditorView,

--- a/src/json-validation.ts
+++ b/src/json-validation.ts
@@ -27,7 +27,7 @@ export type JSONValidationOptions = {
 /**
  * Helper for simpler class instantiaton
  */
-export function lintJSONSchema(
+export function jsonSchemaLiner(
   schema: JSONSchema7,
   options?: JSONValidationOptions
 ) {

--- a/src/json-validation.ts
+++ b/src/json-validation.ts
@@ -41,10 +41,11 @@ export class JSONValidation {
   private schema: Draft;
   private options: JSONValidationOptions;
   public constructor(schema: JSONSchema7, options?: JSONValidationOptions) {
-    this.options = options ?? {};
-    if (!this.options.jsonParser) {
-      this.options.jsonParser = parseJSONDocumentState;
-    }
+    this.options = {
+      jsonParser: parseJSONDocumentState,
+      ...options,
+    };
+
     // TODO: support other versions of json schema.
     // most standard schemas are draft 4 for some reason, probably
     // backwards compatibility

--- a/src/json-validation.ts
+++ b/src/json-validation.ts
@@ -3,8 +3,9 @@ import type { Diagnostic } from "@codemirror/lint";
 import type { JSONSchema7 } from "json-schema";
 import { Draft04, type Draft, type JsonError } from "json-schema-library";
 import { joinWithOr } from "./utils/formatting";
-import { JSONPointerData } from "./utils/jsonPointers";
+import { JSONPointerData } from "./types";
 import { parseJSONDocumentState } from "./utils/parseJSONDocument";
+import { RequiredPick } from "./types";
 
 // return an object path that matches with the json-source-map pointer
 const getErrorPath = (error: JsonError): string => {
@@ -24,10 +25,12 @@ export type JSONValidationOptions = {
   formatError?: (error: JsonError) => string;
   jsonParser?: typeof parseJSONDocumentState;
 };
+
+type JSONValidationSettings = RequiredPick<JSONValidationOptions, "jsonParser">;
 /**
  * Helper for simpler class instantiaton
  */
-export function jsonSchemaLiner(
+export function jsonSchemaLinter(
   schema: JSONSchema7,
   options?: JSONValidationOptions
 ) {
@@ -39,7 +42,7 @@ export function jsonSchemaLiner(
 
 export class JSONValidation {
   private schema: Draft;
-  private options: JSONValidationOptions;
+  private options: JSONValidationSettings;
   public constructor(schema: JSONSchema7, options?: JSONValidationOptions) {
     this.options = {
       jsonParser: parseJSONDocumentState,
@@ -85,7 +88,7 @@ export class JSONValidation {
     // ignore blank json strings
     if (!text || text.trim().length < 3) return [];
 
-    const json = this.options.jsonParser!(view.state);
+    const json = this.options.jsonParser(view.state);
 
     let errors: JsonError[] = [];
     try {

--- a/src/json5-hover.ts
+++ b/src/json5-hover.ts
@@ -5,7 +5,7 @@ import { type JSONSchema7 } from "json-schema";
 /**
  * Instantiates a JSONHover instance with the JSON5 mode
  */
-export function hoverJson5Schema(schema: JSONSchema7, options?: HoverOptions) {
+export function json5SchemaHover(schema: JSONSchema7, options?: HoverOptions) {
   const hover = new JSONHover(schema, { mode: "json5", ...options });
   return async function jsonDoHover(
     view: EditorView,

--- a/src/json5-hover.ts
+++ b/src/json5-hover.ts
@@ -1,0 +1,17 @@
+import { type EditorView } from "codemirror";
+import { type HoverOptions, JSONHover } from "./json-hover";
+import { type JSONSchema7 } from "json-schema";
+
+/**
+ * Instantiates a JSONHover instance with the JSON5 mode
+ */
+export function hoverJson5Schema(schema: JSONSchema7, options?: HoverOptions) {
+  const hover = new JSONHover(schema, { mode: "json5", ...options });
+  return async function jsonDoHover(
+    view: EditorView,
+    pos: number,
+    side: -1 | 1
+  ) {
+    return hover.doHover(view, pos, side);
+  };
+}

--- a/src/json5-validation.ts
+++ b/src/json5-validation.ts
@@ -1,0 +1,20 @@
+import { EditorView } from "codemirror";
+import { JSONValidation, type JSONValidationOptions } from "./json-validation";
+import type { JSONSchema7 } from "json-schema";
+import { parseJSON5DocumentState } from "./utils/parseJSON5Document";
+
+/**
+ * Instantiates a JSONValidation instance with the JSON5 mode
+ */
+export function lintJSON5Schema(
+  schema: JSONSchema7,
+  options?: JSONValidationOptions
+) {
+  const validation = new JSONValidation(schema, {
+    jsonParser: parseJSON5DocumentState,
+    ...options,
+  });
+  return (view: EditorView) => {
+    return validation.doValidation(view);
+  };
+}

--- a/src/json5-validation.ts
+++ b/src/json5-validation.ts
@@ -6,7 +6,7 @@ import { parseJSON5DocumentState } from "./utils/parseJSON5Document";
 /**
  * Instantiates a JSONValidation instance with the JSON5 mode
  */
-export function lintJSON5Schema(
+export function json5SchemaLinter(
   schema: JSONSchema7,
   options?: JSONValidationOptions
 ) {

--- a/src/json5.ts
+++ b/src/json5.ts
@@ -1,0 +1,3 @@
+// json5
+export { json5SchemaLinter } from "./json5-validation";
+export { json5SchemaHover } from "./json5-hover";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,18 @@
+export type RequiredPick<T, F extends keyof T> = Omit<T, F> & Required<Pick<T, F>>;
+
+export type JSONPartialPointerData = {
+    keyFrom: number;
+    keyTo: number;
+  };
+  
+  export type JSONPointerData = {
+    keyFrom: number;
+    keyTo: number;
+    valueFrom: number;
+    valueTo: number;
+  };
+  
+  export type JSONPointersMap = Map<
+    string,
+    JSONPointerData | JSONPartialPointerData
+  >;

--- a/src/utils/jsonPointers.ts
+++ b/src/utils/jsonPointers.ts
@@ -1,6 +1,7 @@
 import { syntaxTree } from "@codemirror/language";
 import { EditorState, Text } from "@codemirror/state";
 import { SyntaxNode, SyntaxNodeRef } from "@lezer/common";
+import { JSONPointersMap } from "../types";
 
 const VAL_NODE_NAME = /^(?:Null|True|False|Object|Array|String|Number)$/;
 
@@ -9,11 +10,11 @@ export type JSONMode = "json4" | "json5";
 // // borrowed from json5 mode, slightly slower than above, but safer
 // TODO: determine from spec if {"prop'name": example} is valid in json5
 function json5PropNameParser(s: string) {
-  if(s.length < 2) return s;
+  if (s.length < 2) return s;
   let first = s[0];
   let last = s[s.length - 1];
   if ((first === `'` && last === `'`) || (first === `"` && last === `"`)) {
-      s = s.slice(1, -1);
+    s = s.slice(1, -1);
   }
   return s;
 }
@@ -79,22 +80,7 @@ export const jsonPointerForPosition = (
   );
 };
 
-export type JSONPartialPointerData = {
-  keyFrom: number;
-  keyTo: number;
-};
 
-export type JSONPointerData = {
-  keyFrom: number;
-  keyTo: number;
-  valueFrom: number;
-  valueTo: number;
-};
-
-export type JSONPointersMap = Map<
-  string,
-  JSONPointerData | JSONPartialPointerData
->;
 
 // retrieve a Map of all the json pointers in a document
 export const getJsonPointers = (

--- a/src/utils/jsonPointers.ts
+++ b/src/utils/jsonPointers.ts
@@ -4,13 +4,7 @@ import { SyntaxNode, SyntaxNodeRef } from "@lezer/common";
 
 const VAL_NODE_NAME = /^(?:Null|True|False|Object|Array|String|Number)$/;
 
-type JSONMode = "json4" | "json5";
-
-
-// 
-// function json5PropNameParser(s: string) {
-//   return s.replaceAll('"', '').replaceAll("'", '');
-// }
+export type JSONMode = "json4" | "json5";
 
 // // borrowed from json5 mode, slightly slower than above, but safer
 // TODO: determine from spec if {"prop'name": example} is valid in json5

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es2017",
         "module": "ESNext",
         "outDir": "dist",
         "strict": true,


### PR DESCRIPTION
- json5 linting, hover
- add demo for json5
- improve styles a bit
- shore up `exports`
- set `es2017` as the target
- much more extensive docs